### PR TITLE
Add a CSS linter

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -34,6 +34,8 @@ jobs:
       run: npm install
     - name: Run linter "eslint"
       run: npm run lint
+    - name: Run linter "stylelint"
+      run: npm run csslint
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -33,7 +33,7 @@ jobs:
     - name: Run npm install
       run: npm install
     - name: Run linter "eslint"
-      run: npm run lint
+      run: npm run jslint
     - name: Run linter "stylelint"
       run: npm run csslint
 

--- a/app/.stylelintrc.json
+++ b/app/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "stylelint-config-standard"
+}

--- a/app/.stylelintrc.json
+++ b/app/.stylelintrc.json
@@ -1,3 +1,6 @@
 {
-    "extends": "stylelint-config-standard"
+    "extends": [
+        "stylelint-config-standard",
+        "stylelint-config-recess-order"
+    ]
 }

--- a/app/.stylelintrc.json
+++ b/app/.stylelintrc.json
@@ -1,6 +1,6 @@
 {
     "extends": [
         "stylelint-config-standard",
-        "stylelint-config-recess-order"
+        "stylelint-config-property-sort-order-smacss"
     ]
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1437,15 +1437,62 @@
         "glob-to-regexp": "^0.3.0"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "dev": true
+        }
+      }
+    },
     "@nodelib/fs.stat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
       "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
+    },
+    "@stylelint/postcss-css-in-js": {
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.1.tgz",
+      "integrity": "sha512-UMf2Rni3JGKi3ZwYRGMYJ5ipOA5ENJSKMtYA/pE1ZLURwdh7B5+z2r73RmWvub+N0UuH1Lo+TGfCgYwPvqpXNw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": ">=7.9.0"
+      }
+    },
+    "@stylelint/postcss-markdown": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.1.tgz",
+      "integrity": "sha512-iDxMBWk9nB2BPi1VFQ+Dc5+XpvODBHw2n3tYpaBZuEAFQlbtF9If0Qh5LTTwSi/XwdbJ2jt+0dis3i8omyggpw==",
+      "dev": true,
+      "requires": {
+        "remark": "^12.0.0",
+        "unist-util-find-all-after": "^3.0.1"
+      }
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.2.0",
@@ -1770,10 +1817,22 @@
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
+    "@types/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "dev": true
+    },
     "@types/node": {
       "version": "14.0.12",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.12.tgz",
       "integrity": "sha512-/sjzehvjkkpvLpYtN6/2dv5kg41otMGuHQUt9T2aiAuIfleCQRQHXXzF1eAw/qkZTj5Kcf4JSTf7EIizHocy6Q=="
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
     },
     "@types/parse-json": {
       "version": "4.0.0",
@@ -1918,6 +1977,12 @@
           }
         }
       }
+    },
+    "@types/unist": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
+      "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "13.0.9",
@@ -2984,6 +3049,12 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
+    "bail": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
+      "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -3445,6 +3516,17 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
     },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
     "caniuse-api": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -3479,6 +3561,12 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "ccount": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
+      "integrity": "sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -3493,6 +3581,12 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
       "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
+    },
+    "character-entities-html4": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-1.1.4.tgz",
+      "integrity": "sha512-HRcDxZuZqMx3/a+qrzxdBKBPUpxWEq9xw2OPZ3a/174ihfrQKVsFhqtthBInFy1zZ9GgZyFXOatNujm8M+El3g==",
+      "dev": true
     },
     "character-entities-legacy": {
       "version": "1.1.4",
@@ -3704,6 +3798,23 @@
         "shallow-clone": "^0.1.2"
       }
     },
+    "clone-regexp": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
+      "dev": true,
+      "requires": {
+        "is-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "is-regexp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+          "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+          "dev": true
+        }
+      }
+    },
     "clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
@@ -3728,6 +3839,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collapse-white-space": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
+      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -4407,6 +4524,24 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "dev": true
+        }
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -6484,6 +6619,15 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "execall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
+      "dev": true,
+      "requires": {
+        "clone-regexp": "^2.1.0"
+      }
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -6792,6 +6936,15 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fastq": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+      "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "fault": {
       "version": "1.0.4",
@@ -7334,6 +7487,21 @@
         }
       }
     },
+    "globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
+      "dev": true
+    },
+    "gonzales-pe": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
     "good-listener": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
@@ -7387,6 +7555,12 @@
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
       }
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true
     },
     "harmony-reflect": {
       "version": "1.6.1",
@@ -7642,6 +7816,12 @@
         }
       }
     },
+    "html-tags": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
+      "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
+      "dev": true
+    },
     "html-webpack-plugin": {
       "version": "4.0.0-beta.11",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.0.0-beta.11.tgz",
@@ -7824,6 +8004,12 @@
       "requires": {
         "resolve-from": "^3.0.0"
       }
+    },
+    "import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true
     },
     "import-local": {
       "version": "2.0.0",
@@ -8022,6 +8208,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
       "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+    },
+    "is-alphanumeric": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+      "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ=",
+      "dev": true
     },
     "is-alphanumerical": {
       "version": "1.0.4",
@@ -8290,10 +8482,22 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "is-whitespace-character": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
+      "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
+      "dev": true
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "is-word-character": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
+      "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
+      "dev": true
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -9145,6 +9349,12 @@
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
+    "known-css-properties": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.19.0.tgz",
+      "integrity": "sha512-eYboRV94Vco725nKMlpkn3nV2+96p9c3gKXRsYqAJSswSENvBhN7n5L+uDhY58xQa0UukWsDMTGELzmD8Q+wTA==",
+      "dev": true
+    },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/last-call-webpack-plugin/-/last-call-webpack-plugin-3.0.0.tgz",
@@ -9332,10 +9542,77 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
+    "log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "loglevel": {
       "version": "1.6.8",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
       "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA=="
+    },
+    "longest-streak": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
+      "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -9424,6 +9701,12 @@
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
     },
+    "map-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "dev": true
+    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -9431,6 +9714,27 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "markdown-escapes": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
+      "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
+      "dev": true
+    },
+    "markdown-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
+      "integrity": "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A==",
+      "dev": true,
+      "requires": {
+        "repeat-string": "^1.0.0"
+      }
+    },
+    "mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -9440,6 +9744,15 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "mdast-util-compact": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz",
+      "integrity": "sha512-7GlnT24gEwDrdAwEHrU4Vv5lLWrEer4KOkAiKT9nYstsTad7Oc1TwqT2zIMKRdZF7cTuaf+GA1E4Kv7jJh8mPA==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "^2.0.0"
       }
     },
     "mdn-data": {
@@ -9496,6 +9809,165 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "meow": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
+      "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "arrify": "^2.0.1",
+        "camelcase": "^6.0.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "^4.0.2",
+        "normalize-package-data": "^2.5.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.13.1",
+        "yargs-parser": "^18.1.3"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
+            }
+          }
+        },
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
+            }
           }
         }
       }
@@ -9660,6 +10132,25 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
     },
     "minipass": {
       "version": "3.1.3",
@@ -10005,6 +10496,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
+    },
+    "normalize-selector": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
+      "dev": true
     },
     "normalize-url": {
       "version": "1.9.1",
@@ -10976,6 +11473,15 @@
         "postcss": "^7.0.2"
       }
     },
+    "postcss-html": {
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
+      "integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^3.10.0"
+      }
+    },
     "postcss-image-set-function": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz",
@@ -11002,6 +11508,15 @@
         "@csstools/convert-colors": "^1.4.0",
         "postcss": "^7.0.2",
         "postcss-values-parser": "^2.0.0"
+      }
+    },
+    "postcss-less": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
+      "integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.14"
       }
     },
     "postcss-load-config": {
@@ -11051,6 +11566,12 @@
       "requires": {
         "postcss": "^7.0.2"
       }
+    },
+    "postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
+      "dev": true
     },
     "postcss-merge-longhand": {
       "version": "4.0.11",
@@ -11529,12 +12050,60 @@
         "postcss": "^7.0.2"
       }
     },
+    "postcss-reporter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.1.tgz",
+      "integrity": "sha512-LpmQjfRWyabc+fRygxZjpRxfhRf9u/fdlKf4VHG4TSPbV2XNsuISzYW1KL+1aQzx53CAppa1bKG4APIB/DOXXw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "lodash": "^4.17.11",
+        "log-symbols": "^2.2.0",
+        "postcss": "^7.0.7"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1"
+          }
+        }
+      }
+    },
+    "postcss-resolve-nested-selector": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4=",
+      "dev": true
+    },
     "postcss-safe-parser": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.1.tgz",
       "integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
       "requires": {
         "postcss": "^7.0.0"
+      }
+    },
+    "postcss-sass": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.4.tgz",
+      "integrity": "sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==",
+      "dev": true,
+      "requires": {
+        "gonzales-pe": "^4.3.0",
+        "postcss": "^7.0.21"
+      }
+    },
+    "postcss-scss": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
+      "integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.6"
       }
     },
     "postcss-selector-matches": {
@@ -11582,6 +12151,12 @@
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
         }
       }
+    },
+    "postcss-syntax": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
+      "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
+      "dev": true
     },
     "postcss-unique-selectors": {
       "version": "4.0.1",
@@ -11839,6 +12414,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
     },
     "raf": {
       "version": "3.4.1",
@@ -12539,6 +13120,95 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
     },
+    "remark": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/remark/-/remark-12.0.0.tgz",
+      "integrity": "sha512-oX4lMIS0csgk8AEbzY0h2jdR0ngiCHOpwwpxjmRa5TqAkeknY+tkhjRJGZqnCmvyuWh55/0SW5WY3R3nn3PH9A==",
+      "dev": true,
+      "requires": {
+        "remark-parse": "^8.0.0",
+        "remark-stringify": "^8.0.0",
+        "unified": "^9.0.0"
+      }
+    },
+    "remark-parse": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-8.0.2.tgz",
+      "integrity": "sha512-eMI6kMRjsAGpMXXBAywJwiwAse+KNpmt+BK55Oofy4KvBZEqUDj6mWbGLJZrujoPIPPxDXzn3T9baRlpsm2jnQ==",
+      "dev": true,
+      "requires": {
+        "ccount": "^1.0.0",
+        "collapse-white-space": "^1.0.2",
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "is-word-character": "^1.0.0",
+        "markdown-escapes": "^1.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "trim": "0.0.1",
+        "trim-trailing-lines": "^1.0.0",
+        "unherit": "^1.0.4",
+        "unist-util-remove-position": "^2.0.0",
+        "vfile-location": "^3.0.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "parse-entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+          "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+          "dev": true,
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        }
+      }
+    },
+    "remark-stringify": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-8.1.0.tgz",
+      "integrity": "sha512-FSPZv1ds76oAZjurhhuV5qXSUSoz6QRPuwYK38S41sLHwg4oB7ejnmZshj7qwjgYLf93kdz6BOX9j5aidNE7rA==",
+      "dev": true,
+      "requires": {
+        "ccount": "^1.0.0",
+        "is-alphanumeric": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-whitespace-character": "^1.0.0",
+        "longest-streak": "^2.0.1",
+        "markdown-escapes": "^1.0.0",
+        "markdown-table": "^2.0.0",
+        "mdast-util-compact": "^2.0.0",
+        "parse-entities": "^2.0.0",
+        "repeat-string": "^1.5.4",
+        "state-toggle": "^1.0.0",
+        "stringify-entities": "^3.0.0",
+        "unherit": "^1.0.4",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "parse-entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+          "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+          "dev": true,
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        }
+      }
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -12605,6 +13275,12 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+      "dev": true
     },
     "request": {
       "version": "2.88.2",
@@ -12809,6 +13485,12 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rework": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
@@ -12866,6 +13548,12 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+    },
+    "run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
     },
     "run-queue": {
       "version": "1.0.3",
@@ -13556,6 +14244,12 @@
         "wbuf": "^1.7.3"
       }
     },
+    "specificity": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+      "dev": true
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -13603,6 +14297,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+    },
+    "state-toggle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
+      "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
+      "dev": true
     },
     "static-extend": {
       "version": "0.1.2",
@@ -13846,6 +14546,19 @@
         }
       }
     },
+    "stringify-entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.0.1.tgz",
+      "integrity": "sha512-Lsk3ISA2++eJYqBMPKcr/8eby1I6L0gP0NlxF8Zja6c05yr/yCYyb2c9PwXjd08Ib3If1vn1rbs1H5ZtVuOfvQ==",
+      "dev": true,
+      "requires": {
+        "character-entities-html4": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.2",
+        "is-hexadecimal": "^1.0.0"
+      }
+    },
     "stringify-object": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
@@ -13924,6 +14637,12 @@
         }
       }
     },
+    "style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
+      "dev": true
+    },
     "stylehacks": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-4.0.3.tgz",
@@ -13946,6 +14665,339 @@
         }
       }
     },
+    "stylelint": {
+      "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.6.1.tgz",
+      "integrity": "sha512-XyvKyNE7eyrqkuZ85Citd/Uv3ljGiuYHC6UiztTR6sWS9rza8j3UeQv/eGcQS9NZz/imiC4GKdk1EVL3wst5vw==",
+      "dev": true,
+      "requires": {
+        "@stylelint/postcss-css-in-js": "^0.37.1",
+        "@stylelint/postcss-markdown": "^0.36.1",
+        "autoprefixer": "^9.8.0",
+        "balanced-match": "^1.0.0",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^6.0.0",
+        "debug": "^4.1.1",
+        "execall": "^2.0.0",
+        "file-entry-cache": "^5.0.1",
+        "get-stdin": "^8.0.0",
+        "global-modules": "^2.0.0",
+        "globby": "^11.0.1",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.1.0",
+        "ignore": "^5.1.8",
+        "import-lazy": "^4.0.0",
+        "imurmurhash": "^0.1.4",
+        "known-css-properties": "^0.19.0",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.15",
+        "log-symbols": "^4.0.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^7.0.1",
+        "micromatch": "^4.0.2",
+        "normalize-selector": "^0.2.0",
+        "postcss": "^7.0.32",
+        "postcss-html": "^0.36.0",
+        "postcss-less": "^3.1.4",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-reporter": "^6.0.1",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-safe-parser": "^4.0.2",
+        "postcss-sass": "^0.4.4",
+        "postcss-scss": "^2.1.1",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-syntax": "^0.36.2",
+        "postcss-value-parser": "^4.1.0",
+        "resolve-from": "^5.0.0",
+        "slash": "^3.0.0",
+        "specificity": "^0.4.1",
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "style-search": "^0.1.0",
+        "sugarss": "^2.0.0",
+        "svg-tags": "^1.0.0",
+        "table": "^5.4.6",
+        "v8-compile-cache": "^2.1.1",
+        "write-file-atomic": "^3.0.3"
+      },
+      "dependencies": {
+        "@nodelib/fs.stat": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+          "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "dir-glob": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+          "dev": true,
+          "requires": {
+            "path-type": "^4.0.0"
+          }
+        },
+        "fast-glob": {
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+          "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.0",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.2",
+            "picomatch": "^2.2.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "get-stdin": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+          "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+          "dev": true
+        },
+        "globby": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+          "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          },
+          "dependencies": {
+            "resolve-from": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+              "dev": true
+            }
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+          "dev": true
+        },
+        "postcss-safe-parser": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
+          "integrity": "sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==",
+          "dev": true,
+          "requires": {
+            "postcss": "^7.0.26"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        }
+      }
+    },
+    "stylelint-config-recommended": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
+      "integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
+      "dev": true
+    },
+    "stylelint-config-standard": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-20.0.0.tgz",
+      "integrity": "sha512-IB2iFdzOTA/zS4jSVav6z+wGtin08qfj+YyExHB3LF9lnouQht//YyB0KZq9gGz5HNPkddHOzcY8HsUey6ZUlA==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-recommended": "^3.0.0"
+      }
+    },
+    "sugarss": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
+      "integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.2"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -13958,6 +15010,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
+    },
+    "svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=",
+      "dev": true
     },
     "svgo": {
       "version": "1.3.2",
@@ -14312,10 +15370,34 @@
         "punycode": "^2.1.0"
       }
     },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+      "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
+      "dev": true
+    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "trim-trailing-lines": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.3.tgz",
+      "integrity": "sha512-4ku0mmjXifQcTVfYDfR5lpgV7zVqPg6zV9rdZmwOPqq0+Zq19xDqEgagqVbc4pOOShbncuAOIs59R3+3gcF3ZA==",
+      "dev": true
+    },
+    "trough": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
+      "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
       "dev": true
     },
     "ts-pnp": {
@@ -14386,6 +15468,25 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
+    "unherit": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
+      "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -14409,6 +15510,34 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg=="
+    },
+    "unified": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-9.0.0.tgz",
+      "integrity": "sha512-ssFo33gljU3PdlWLjNp15Inqb77d6JnJSfyplGJPT/a+fNRNyCBeveBAYJdO5khKdF6WVHa/yYCC7Xl6BDwZUQ==",
+      "dev": true,
+      "requires": {
+        "bail": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-buffer": "^2.0.0",
+        "is-plain-obj": "^2.0.0",
+        "trough": "^1.0.0",
+        "vfile": "^4.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "dev": true
+        }
+      }
     },
     "union-value": {
       "version": "1.0.1",
@@ -14445,6 +15574,60 @@
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "requires": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "unist-util-find-all-after": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.1.tgz",
+      "integrity": "sha512-0GICgc++sRJesLwEYDjFVJPJttBpVQaTNgc6Jw0Jhzvfs+jtKePEMu+uD+PqkRUrAvGQqwhpDwLGWo1PK8PDEw==",
+      "dev": true,
+      "requires": {
+        "unist-util-is": "^4.0.0"
+      }
+    },
+    "unist-util-is": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.0.2.tgz",
+      "integrity": "sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==",
+      "dev": true
+    },
+    "unist-util-remove-position": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-2.0.1.tgz",
+      "integrity": "sha512-fDZsLYIe2uT+oGFnuZmy73K6ZxOPG/Qcm+w7jbEjaFcJgbQ6cqjs/eSPzXhsmGpAsWPkqZM9pYjww5QTn3LHMA==",
+      "dev": true,
+      "requires": {
+        "unist-util-visit": "^2.0.0"
+      }
+    },
+    "unist-util-stringify-position": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+      "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.2"
+      }
+    },
+    "unist-util-visit": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.2.tgz",
+      "integrity": "sha512-HoHNhGnKj6y+Sq+7ASo2zpVdfdRifhTgX2KTU3B/sO/TTlZchp7E3S4vjRzDJ7L60KmrCPsQkVK3lEF3cz36XQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      }
+    },
+    "unist-util-visit-parents": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.0.2.tgz",
+      "integrity": "sha512-yJEfuZtzFpQmg1OSCyS9M5NJRrln/9FbYosH3iW0MG402QbdbaB8ZESwUv9RO6nRfLAKvWcMxCwdLWOov36x/g==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
       }
     },
     "universalify": {
@@ -14653,6 +15836,43 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "vfile": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.1.1.tgz",
+      "integrity": "sha512-lRjkpyDGjVlBA7cDQhQ+gNcvB1BGaTHYuSOcY3S7OhDmBtnzX95FhtZZDecSTDm6aajFymyve6S5DN4ZHGezdQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "is-buffer": "^2.0.0",
+        "replace-ext": "1.0.0",
+        "unist-util-stringify-position": "^2.0.0",
+        "vfile-message": "^2.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
+      }
+    },
+    "vfile-location": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-3.0.1.tgz",
+      "integrity": "sha512-yYBO06eeN/Ki6Kh1QAkgzYpWT1d3Qln+ZCtSbJqFExPl1S3y2qqotJQXoh6qEvl/jDlgpUJolBn3PItVnnZRqQ==",
+      "dev": true
+    },
+    "vfile-message": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+      "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
       }
     },
     "vm-browserify": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4296,6 +4296,12 @@
         "postcss": "^7.0.5"
       }
     },
+    "css-property-sort-order-smacss": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/css-property-sort-order-smacss/-/css-property-sort-order-smacss-2.1.3.tgz",
+      "integrity": "sha512-tMGlBxcfQq5VYmMFp4tGqxkNeXDBmlGbyuuz1FFGRvCUj9CvocShe23d4kFyfxW6JMlhlBVfnZRa8AO8kgceJA==",
+      "dev": true
+    },
     "css-select": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
@@ -14984,13 +14990,14 @@
         }
       }
     },
-    "stylelint-config-recess-order": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/stylelint-config-recess-order/-/stylelint-config-recess-order-2.0.4.tgz",
-      "integrity": "sha512-lWCVL5VyEGz4MOFDhPt79ibhv+E3mqerd/8thzOCN7Nuk+rGNR/AebtyHNeKm1xMm5Ri6czHGxWPXwmrSPo3yQ==",
+    "stylelint-config-property-sort-order-smacss": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-property-sort-order-smacss/-/stylelint-config-property-sort-order-smacss-6.3.0.tgz",
+      "integrity": "sha512-NX7vQvtcXhFZYOb90maGXuoBxWOGRlcNvKzqZ0BSl0i9EU0/lpS0ZE9G6PLxkrn1SxSv7FV8Hu0JCWFan8tlLA==",
       "dev": true,
       "requires": {
-        "stylelint-order": "4.0.x"
+        "css-property-sort-order-smacss": "~2.1.3",
+        "stylelint-order": "^4.0.0"
       }
     },
     "stylelint-config-recommended": {
@@ -15009,13 +15016,13 @@
       }
     },
     "stylelint-order": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-4.0.0.tgz",
-      "integrity": "sha512-bXV0v+jfB0+JKsqIn3mLglg1Dj2QCYkFHNfL1c+rVMEmruZmW5LUqT/ARBERfBm8SFtCuXpEdatidw/3IkcoiA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-4.1.0.tgz",
+      "integrity": "sha512-sVTikaDvMqg2aJjh4r48jsdfmqLT+nqB1MOsaBnvM3OwLx4S+WXcsxsgk5w18h/OZoxZCxuyXMh61iBHcj9Qiw==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.15",
-        "postcss": "^7.0.26",
+        "postcss": "^7.0.31",
         "postcss-sorting": "^5.0.1"
       }
     },

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12134,6 +12134,16 @@
         "uniq": "^1.0.1"
       }
     },
+    "postcss-sorting": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-sorting/-/postcss-sorting-5.0.1.tgz",
+      "integrity": "sha512-Y9fUFkIhfrm6i0Ta3n+89j56EFqaNRdUKqXyRp6kvTcSXnmgEjaVowCXH+JBe9+YKWqd4nc28r2sgwnzJalccA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14",
+        "postcss": "^7.0.17"
+      }
+    },
     "postcss-svgo": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-4.0.2.tgz",
@@ -14974,6 +14984,15 @@
         }
       }
     },
+    "stylelint-config-recess-order": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recess-order/-/stylelint-config-recess-order-2.0.4.tgz",
+      "integrity": "sha512-lWCVL5VyEGz4MOFDhPt79ibhv+E3mqerd/8thzOCN7Nuk+rGNR/AebtyHNeKm1xMm5Ri6czHGxWPXwmrSPo3yQ==",
+      "dev": true,
+      "requires": {
+        "stylelint-order": "4.0.x"
+      }
+    },
     "stylelint-config-recommended": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
@@ -14987,6 +15006,17 @@
       "dev": true,
       "requires": {
         "stylelint-config-recommended": "^3.0.0"
+      }
+    },
+    "stylelint-order": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-order/-/stylelint-order-4.0.0.tgz",
+      "integrity": "sha512-bXV0v+jfB0+JKsqIn3mLglg1Dj2QCYkFHNfL1c+rVMEmruZmW5LUqT/ARBERfBm8SFtCuXpEdatidw/3IkcoiA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "postcss": "^7.0.26",
+        "postcss-sorting": "^5.0.1"
       }
     },
     "sugarss": {

--- a/app/package.json
+++ b/app/package.json
@@ -37,8 +37,8 @@
     "eject": "react-scripts eject",
     "lint": "eslint -c ./.eslintrc . --ext jsx,js",
     "lint-fix": "eslint -c ./.eslintrc . --ext jsx,js --fix",
-    "csslint": "npx stylelint 'src/**/*.css' --syntax css",
-    "csslint-fix": "npx stylelint 'src/**/*.css' --syntax css --fix"
+    "csslint": "stylelint 'src/**/*.css' --syntax css",
+    "csslint-fix": "stylelint 'src/**/*.css' --syntax css --fix"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/app/package.json
+++ b/app/package.json
@@ -36,8 +36,10 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint -c ./.eslintrc . --ext jsx,js",
-    "lint-fix": "eslint -c ./.eslintrc . --ext jsx,js --fix",
+    "lint": "npm run jslint && npm run csslint",
+    "lint-fix": "npm run jslint-fix && npm run csslint-fix",
+    "jslint": "eslint -c ./.eslintrc . --ext jsx,js",
+    "jslint-fix": "eslint -c ./.eslintrc . --ext jsx,js --fix",
     "csslint": "stylelint 'src/**/*.css' --syntax css",
     "csslint-fix": "stylelint 'src/**/*.css' --syntax css --fix"
   },

--- a/app/package.json
+++ b/app/package.json
@@ -28,7 +28,7 @@
     "eslint-plugin-react": "^7.10.0",
     "prettier": "^1.14.3",
     "stylelint": "^13.6.1",
-    "stylelint-config-recess-order": "^2.0.4",
+    "stylelint-config-property-sort-order-smacss": "^6.3.0",
     "stylelint-config-standard": "^20.0.0"
   },
   "scripts": {

--- a/app/package.json
+++ b/app/package.json
@@ -26,7 +26,9 @@
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-prettier": "^3.0.0",
     "eslint-plugin-react": "^7.10.0",
-    "prettier": "^1.14.3"
+    "prettier": "^1.14.3",
+    "stylelint": "^13.6.1",
+    "stylelint-config-standard": "^20.0.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -34,7 +36,9 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint -c ./.eslintrc . --ext jsx,js",
-    "lint-fix": "eslint -c ./.eslintrc . --ext jsx,js --fix"
+    "lint-fix": "eslint -c ./.eslintrc . --ext jsx,js --fix",
+    "csslint": "npx stylelint 'src/**/*.css' --syntax css",
+    "csslint-fix": "npx stylelint 'src/**/*.css' --syntax css --fix"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
     "eslint-plugin-react": "^7.10.0",
     "prettier": "^1.14.3",
     "stylelint": "^13.6.1",
+    "stylelint-config-recess-order": "^2.0.4",
     "stylelint-config-standard": "^20.0.0"
   },
   "scripts": {

--- a/app/src/components/ClassView/ClassView.css
+++ b/app/src/components/ClassView/ClassView.css
@@ -1,22 +1,20 @@
 .description {
-    font-size: 36px;
-    line-height: 42px;
-    margin-top: 5px;
-    /*color: #000000;*/
+  font-size: 36px;
+  line-height: 42px;
+  margin-top: 5px;
 
+  /* color: #000000; */
 }
 
 .comment {
-    border-style: solid;
-    border-width: 2px;
-    border-color: #175578;
-    margin: 20px 40px;
-    padding: 10px;
-    background-color: #6291ac;
-    
+  border-style: solid;
+  border-width: 2px;
+  border-color: #175578;
+  margin: 20px 40px;
+  padding: 10px;
+  background-color: #6291ac;
 }
 
 .commentText {
-    color: #ffffff;
+  color: #fff;
 }
-

--- a/app/src/components/ClassView/ClassView.css
+++ b/app/src/components/ClassView/ClassView.css
@@ -1,18 +1,18 @@
 .description {
+  margin-top: 5px;
   font-size: 36px;
   line-height: 42px;
-  margin-top: 5px;
 
   /* color: #000000; */
 }
 
 .comment {
+  padding: 10px;
+  margin: 20px 40px;
+  background-color: #6291ac;
+  border-color: #175578;
   border-style: solid;
   border-width: 2px;
-  border-color: #175578;
-  margin: 20px 40px;
-  padding: 10px;
-  background-color: #6291ac;
 }
 
 .commentText {

--- a/app/src/components/ClassView/ClassView.css
+++ b/app/src/components/ClassView/ClassView.css
@@ -7,12 +7,12 @@
 }
 
 .comment {
-  padding: 10px;
   margin: 20px 40px;
-  background-color: #6291ac;
-  border-color: #175578;
-  border-style: solid;
+  padding: 10px;
   border-width: 2px;
+  border-style: solid;
+  border-color: #175578;
+  background-color: #6291ac;
 }
 
 .commentText {

--- a/app/src/components/MethodView/MethodView.css
+++ b/app/src/components/MethodView/MethodView.css
@@ -1,14 +1,14 @@
 .code {
   margin: 20px;
+  border-width: 2px;
+  border-style: solid;
+  border-color: #175578;
+  color: #585858;
   font-size: 0.9rem;
   font-weight: 200;
-  color: #585858;
-  border-color: #175578;
-  border-style: solid;
-  border-width: 2px;
 }
 
 .comment {
-  font-size: 0.9rem;
   color: #fff;
+  font-size: 0.9rem;
 }

--- a/app/src/components/MethodView/MethodView.css
+++ b/app/src/components/MethodView/MethodView.css
@@ -1,11 +1,11 @@
 .code {
-  font-weight: 200;
-  font-size: 0.9rem;
   margin: 20px;
+  font-size: 0.9rem;
+  font-weight: 200;
   color: #585858;
   border-color: #175578;
-  border-width: 2px;
   border-style: solid;
+  border-width: 2px;
 }
 
 .comment {

--- a/app/src/components/MethodView/MethodView.css
+++ b/app/src/components/MethodView/MethodView.css
@@ -1,14 +1,14 @@
-.code{
-    font-weight: 200;
-    font-size: 0.9rem;
-    margin: 20px;
-    color: #585858;
-    border-color: #175578;
-    border-width: 2px;
-    border-style: solid;
+.code {
+  font-weight: 200;
+  font-size: 0.9rem;
+  margin: 20px;
+  color: #585858;
+  border-color: #175578;
+  border-width: 2px;
+  border-style: solid;
 }
 
-.comment{
-    font-size: 0.9rem;
-    color: #FFFFFF;
+.comment {
+  font-size: 0.9rem;
+  color: #fff;
 }

--- a/app/src/components/SearchExplorer/SearchExplorer.css
+++ b/app/src/components/SearchExplorer/SearchExplorer.css
@@ -1,0 +1,1 @@
+/* not required yet */

--- a/app/src/components/Sidebars/CategoriesSidebar/CategoriesList.css
+++ b/app/src/components/Sidebars/CategoriesSidebar/CategoriesList.css
@@ -1,19 +1,19 @@
-.categoriesList{
-    position: relative;
-    left: 10%;
-    list-style-type: none;
+.categoriesList {
+  position: relative;
+  left: 10%;
+  list-style-type: none;
 }
 
-.categoryButton{
-    width: 350px;
-    font-size: 1.2rem;
-    padding: 2px;
-    text-align: left;
-    border: none;
-    background: none;
-    color: #FFFFFF;
+.categoryButton {
+  width: 350px;
+  font-size: 1.2rem;
+  padding: 2px;
+  text-align: left;
+  border: none;
+  background: none;
+  color: #fff;
 }
 
 .categoryButton:hover {
-    color: #cfcfcf;
+  color: #cfcfcf;
 }

--- a/app/src/components/Sidebars/CategoriesSidebar/CategoriesList.css
+++ b/app/src/components/Sidebars/CategoriesSidebar/CategoriesList.css
@@ -7,11 +7,11 @@
 .categoryButton {
   width: 350px;
   padding: 2px;
-  font-size: 1.2rem;
-  color: #fff;
-  text-align: left;
-  background: none;
   border: none;
+  background: none;
+  color: #fff;
+  font-size: 1.2rem;
+  text-align: left;
 }
 
 .categoryButton:hover {

--- a/app/src/components/Sidebars/CategoriesSidebar/CategoriesList.css
+++ b/app/src/components/Sidebars/CategoriesSidebar/CategoriesList.css
@@ -6,12 +6,12 @@
 
 .categoryButton {
   width: 350px;
-  font-size: 1.2rem;
   padding: 2px;
-  text-align: left;
-  border: none;
-  background: none;
+  font-size: 1.2rem;
   color: #fff;
+  text-align: left;
+  background: none;
+  border: none;
 }
 
 .categoryButton:hover {

--- a/app/src/components/Sidebars/CategoriesSidebar/ClassList.css
+++ b/app/src/components/Sidebars/CategoriesSidebar/ClassList.css
@@ -1,27 +1,27 @@
-.classLink{
-    position: relative;
-    word-wrap: break-word;
-    width: 10px;
-    font-size: 1.1rem;
-    padding: 5px;
-    text-align: center;
-    text-decoration: none;
-    color: inherit;
+.classLink {
+  position: relative;
+  word-wrap: break-word;
+  width: 10px;
+  font-size: 1.1rem;
+  padding: 5px;
+  text-align: center;
+  text-decoration: none;
+  color: inherit;
 }
 
-.classLinkBox{
-    width: 300px;
-    color: #FFFFFF;
+.classLinkBox {
+  width: 300px;
+  color: #fff;
 }
 
 .classLinkBox:hover {
-    background: #f1f1f1;
-    padding-left: 10px;
-    color: #175578;
+  background: #f1f1f1;
+  padding-left: 10px;
+  color: #175578;
 }
 
-.classList{
-    position: relative;
-    left: 5%;
-    list-style-type: none;
+.classList {
+  position: relative;
+  left: 5%;
+  list-style-type: none;
 }

--- a/app/src/components/Sidebars/CategoriesSidebar/ClassList.css
+++ b/app/src/components/Sidebars/CategoriesSidebar/ClassList.css
@@ -2,8 +2,8 @@
   position: relative;
   width: 10px;
   padding: 5px;
-  font-size: 1.1rem;
   color: inherit;
+  font-size: 1.1rem;
   text-align: center;
   text-decoration: none;
   word-wrap: break-word;
@@ -16,8 +16,8 @@
 
 .classLinkBox:hover {
   padding-left: 10px;
-  color: #175578;
   background: #f1f1f1;
+  color: #175578;
 }
 
 .classList {

--- a/app/src/components/Sidebars/CategoriesSidebar/ClassList.css
+++ b/app/src/components/Sidebars/CategoriesSidebar/ClassList.css
@@ -1,12 +1,12 @@
 .classLink {
   position: relative;
-  word-wrap: break-word;
   width: 10px;
-  font-size: 1.1rem;
   padding: 5px;
+  font-size: 1.1rem;
+  color: inherit;
   text-align: center;
   text-decoration: none;
-  color: inherit;
+  word-wrap: break-word;
 }
 
 .classLinkBox {
@@ -15,9 +15,9 @@
 }
 
 .classLinkBox:hover {
-  background: #f1f1f1;
   padding-left: 10px;
   color: #175578;
+  background: #f1f1f1;
 }
 
 .classList {

--- a/app/src/components/Sidebars/MethodSidebar/MethodList.css
+++ b/app/src/components/Sidebars/MethodSidebar/MethodList.css
@@ -6,8 +6,8 @@
 
 .LinkText {
   position: relative;
-  font-size: 1.2rem;
   color: #fff;
+  font-size: 1.2rem;
   text-align: center;
   text-decoration: none;
 }

--- a/app/src/components/Sidebars/MethodSidebar/MethodList.css
+++ b/app/src/components/Sidebars/MethodSidebar/MethodList.css
@@ -1,21 +1,21 @@
 .methodList {
-    position: relative;
-    left: 14%;
-    list-style-type: none;
+  position: relative;
+  left: 14%;
+  list-style-type: none;
 }
 
 .LinkText {
-    position: relative;
-    font-size: 1.2rem;
-    text-align: center;
-    text-decoration: none;
-    color: #FFFFFF;
+  position: relative;
+  font-size: 1.2rem;
+  text-align: center;
+  text-decoration: none;
+  color: #fff;
 }
 
 .LinkText:hover {
-    color: #cfcfcf;
+  color: #cfcfcf;
 }
 
 li {
-    position: relative;
+  position: relative;
 }

--- a/app/src/components/Sidebars/MethodSidebar/MethodList.css
+++ b/app/src/components/Sidebars/MethodSidebar/MethodList.css
@@ -7,9 +7,9 @@
 .LinkText {
   position: relative;
   font-size: 1.2rem;
+  color: #fff;
   text-align: center;
   text-decoration: none;
-  color: #fff;
 }
 
 .LinkText:hover {

--- a/app/src/components/Sidebars/MethodSidebar/MethodSidebar.css
+++ b/app/src/components/Sidebars/MethodSidebar/MethodSidebar.css
@@ -1,14 +1,16 @@
 .backToCategoriesBtn {
-    padding: 10px 24px;
-    /* Some padding */
-    cursor: pointer;
-    /* Pointer/hand icon */
-    position: relative;
-    margin: 20px 10px;
-    width: 40%;
-    height: 41px;
-    left: 11px;
-    top: 80%;
-    background: #FFFFFF;
-    box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.25);
+  padding: 10px 24px;
+
+  /* Some padding */
+  cursor: pointer;
+
+  /* Pointer/hand icon */
+  position: relative;
+  margin: 20px 10px;
+  width: 40%;
+  height: 41px;
+  left: 11px;
+  top: 80%;
+  background: #fff;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
 }

--- a/app/src/components/Sidebars/MethodSidebar/MethodSidebar.css
+++ b/app/src/components/Sidebars/MethodSidebar/MethodSidebar.css
@@ -5,11 +5,11 @@
   left: 11px;
   width: 40%;
   height: 41px;
-  padding: 10px 24px;
   margin: 20px 10px;
+  padding: 10px 24px;
+  background: #fff;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
 
   /* Some padding */
   cursor: pointer;
-  background: #fff;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
 }

--- a/app/src/components/Sidebars/MethodSidebar/MethodSidebar.css
+++ b/app/src/components/Sidebars/MethodSidebar/MethodSidebar.css
@@ -1,16 +1,15 @@
 .backToCategoriesBtn {
+  /* Pointer/hand icon */
+  position: relative;
+  top: 80%;
+  left: 11px;
+  width: 40%;
+  height: 41px;
   padding: 10px 24px;
+  margin: 20px 10px;
 
   /* Some padding */
   cursor: pointer;
-
-  /* Pointer/hand icon */
-  position: relative;
-  margin: 20px 10px;
-  width: 40%;
-  height: 41px;
-  left: 11px;
-  top: 80%;
   background: #fff;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.25);
 }

--- a/app/src/components/Sidebars/SidebarHeader/SidebarHeader.css
+++ b/app/src/components/Sidebars/SidebarHeader/SidebarHeader.css
@@ -10,8 +10,8 @@
 }
 
 .openedHead {
-  position: relative;
   display: flex;
+  position: relative;
   align-items: row;
   height: 90px;
 }
@@ -26,16 +26,16 @@
 }
 
 .headTitle {
-  position: relative;
   display: flex;
+  position: relative;
   align-items: center;
   margin-top: -65px;
   margin-bottom: 20px;
   margin-left: 130px;
+  color: #fff;
   font-size: 48px;
   font-weight: bold;
   line-height: 56px;
-  color: #fff;
   text-align: center;
 }
 

--- a/app/src/components/Sidebars/SidebarHeader/SidebarHeader.css
+++ b/app/src/components/Sidebars/SidebarHeader/SidebarHeader.css
@@ -1,58 +1,58 @@
 .closedHead {
-  width: 50px;
-  height: 50px;
-  margin-top: 50px;
   position: fixed;
   top: 0;
   left: 0;
+  width: 50px;
+  height: 50px;
+  margin-top: 50px;
   overflow-x: hidden;
   background: #175578;
 }
 
 .openedHead {
   position: relative;
-  height: 90px;
   display: flex;
   align-items: row;
+  height: 90px;
 }
 
 .logo {
   position: relative;
+  z-index: 1;
   width: 90px;
   height: 63px;
   margin: 5px;
   margin-left: 20px;
-  z-index: 1;
 }
 
 .headTitle {
   position: relative;
-  font-weight: bold;
-  font-size: 48px;
-  line-height: 56px;
   display: flex;
   align-items: center;
-  text-align: center;
   margin-top: -65px;
-  margin-left: 130px;
   margin-bottom: 20px;
+  margin-left: 130px;
+  font-size: 48px;
+  font-weight: bold;
+  line-height: 56px;
   color: #fff;
+  text-align: center;
 }
 
 .openButton {
+  width: 36px;
+  height: 36px;
   margin-top: 7px;
   margin-left: 7px;
-  height: 36px;
-  width: 36px;
   background: #fff;
 }
 
 .closeButton {
-  margin-left: 20px;
-  margin-bottom: 30px;
-  margin-top: 22px;
-  height: 36px;
   width: 36px;
+  height: 36px;
+  margin-top: 22px;
+  margin-bottom: 30px;
+  margin-left: 20px;
   background: #fff;
 }
 

--- a/app/src/components/Sidebars/SidebarHeader/SidebarHeader.css
+++ b/app/src/components/Sidebars/SidebarHeader/SidebarHeader.css
@@ -1,75 +1,74 @@
-.closedHead{
-    width: 50px;
-    height: 50px;
-    margin-top: 50px;
-    position: fixed;
-    top: 0;
-    left: 0;
-    background-color: #111;
-    overflow-x: hidden;
-    background: #175578;
+.closedHead {
+  width: 50px;
+  height: 50px;
+  margin-top: 50px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  overflow-x: hidden;
+  background: #175578;
 }
 
-.openedHead{
-    position: relative;
-    height: 90px;
-    display: flex;
-    align-items: row;
+.openedHead {
+  position: relative;
+  height: 90px;
+  display: flex;
+  align-items: row;
 }
 
 .logo {
-    position: relative;
-    width: 90px;
-    height: 63px;
-    margin: 5px;
-    margin-left: 20px;
-    z-index: 1;
+  position: relative;
+  width: 90px;
+  height: 63px;
+  margin: 5px;
+  margin-left: 20px;
+  z-index: 1;
 }
 
-.headTitle{
-    position: relative;
-    font-weight: bold;
-    font-size: 48px;
-    line-height: 56px;
-    display: flex;
-    align-items: center;
-    text-align: center;
-    margin-top: -65px;
-    margin-left: 130px;
-    margin-bottom: 20px;
-    color: #FFFFFF;
+.headTitle {
+  position: relative;
+  font-weight: bold;
+  font-size: 48px;
+  line-height: 56px;
+  display: flex;
+  align-items: center;
+  text-align: center;
+  margin-top: -65px;
+  margin-left: 130px;
+  margin-bottom: 20px;
+  color: #fff;
 }
 
-.openButton{
-    margin-top: 7px;
-    margin-left: 7px;
-    height: 36px;
-    width: 36px;
-    background: #FFFFFF;
+.openButton {
+  margin-top: 7px;
+  margin-left: 7px;
+  height: 36px;
+  width: 36px;
+  background: #fff;
 }
 
-.closeButton{
-    margin-left: 20px;
-    margin-bottom: 30px;
-    margin-top: 22px;
-    height: 36px;
-    width: 36px;
-    background: #FFFFFF;
+.closeButton {
+  margin-left: 20px;
+  margin-bottom: 30px;
+  margin-top: 22px;
+  height: 36px;
+  width: 36px;
+  background: #fff;
 }
 
 .openPic {
-    position: relative;
-    top: -1px;
-    left: -2px;
-    width: 36px;
-    height: 36px;
-    transform: rotate(180deg);
+  position: relative;
+  top: -1px;
+  left: -2px;
+  width: 36px;
+  height: 36px;
+  transform: rotate(180deg);
 }
 
 .closePic {
-    position: relative;
-    top: -3px;
-    left: -2px;
-    width: 36px;
-    height: 36px;
+  position: relative;
+  top: -3px;
+  left: -2px;
+  width: 36px;
+  height: 36px;
 }

--- a/app/src/components/Sidebars/Sidebars.css
+++ b/app/src/components/Sidebars/Sidebars.css
@@ -1,11 +1,11 @@
 .sidenav {
-  height: 100%;
   position: fixed;
-  z-index: 1;
   top: 0;
   left: 0;
-  overflow-x: hidden;
+  z-index: 1;
+  height: 100%;
   padding-top: 20px;
+  overflow-x: hidden;
   background: #175578;
 }
 
@@ -19,14 +19,14 @@
 
 .secondarySidebarTitle {
   position: relative;
-  font-size: 2rem;
-  text-align: left;
-  margin-left: 15px;
   margin-bottom: 10px;
+  margin-left: 15px;
+  font-size: 2rem;
   color: #fff;
+  text-align: left;
 }
 
 .secondarySidebarTitleLink {
-  text-decoration: none;
   color: #fff;
+  text-decoration: none;
 }

--- a/app/src/components/Sidebars/Sidebars.css
+++ b/app/src/components/Sidebars/Sidebars.css
@@ -1,8 +1,8 @@
 .sidenav {
   position: fixed;
+  z-index: 1;
   top: 0;
   left: 0;
-  z-index: 1;
   height: 100%;
   padding-top: 20px;
   overflow-x: hidden;
@@ -21,8 +21,8 @@
   position: relative;
   margin-bottom: 10px;
   margin-left: 15px;
-  font-size: 2rem;
   color: #fff;
+  font-size: 2rem;
   text-align: left;
 }
 

--- a/app/src/components/Sidebars/Sidebars.css
+++ b/app/src/components/Sidebars/Sidebars.css
@@ -1,33 +1,32 @@
 .sidenav {
-    height: 100%;
-    position: fixed;
-    z-index: 1;
-    top: 0;
-    left: 0;
-    background-color: #111;
-    overflow-x: hidden;
-    padding-top: 20px;
-    background: #175578;
+  height: 100%;
+  position: fixed;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  overflow-x: hidden;
+  padding-top: 20px;
+  background: #175578;
 }
 
 #openSidebarBox {
-    width: 417px;
+  width: 417px;
 }
 
 #closedSidebarBox {
-    width: 50px;
+  width: 50px;
 }
 
-.secondarySidebarTitle{
-    position: relative;
-    font-size: 2rem;
-    text-align: left;
-    margin-left: 15px;
-    margin-bottom: 10px;
-    color: #FFFFFF;
+.secondarySidebarTitle {
+  position: relative;
+  font-size: 2rem;
+  text-align: left;
+  margin-left: 15px;
+  margin-bottom: 10px;
+  color: #fff;
 }
 
 .secondarySidebarTitleLink {
-    text-decoration: none;
-    color: #FFFFFF;
+  text-decoration: none;
+  color: #fff;
 }

--- a/app/src/routes/App/App.css
+++ b/app/src/routes/App/App.css
@@ -18,14 +18,14 @@
 }
 
 .App-header {
-  background-color: #282c34;
-  min-height: 100vh;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  min-height: 100vh;
   font-size: calc(10px + 2vmin);
   color: white;
+  background-color: #282c34;
 }
 
 .App-link {

--- a/app/src/routes/App/App.css
+++ b/app/src/routes/App/App.css
@@ -36,6 +36,7 @@
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(360deg);
   }

--- a/app/src/routes/App/App.css
+++ b/app/src/routes/App/App.css
@@ -23,9 +23,9 @@
   align-items: center;
   justify-content: center;
   min-height: 100vh;
-  font-size: calc(10px + 2vmin);
-  color: white;
   background-color: #282c34;
+  color: white;
+  font-size: calc(10px + 2vmin);
 }
 
 .App-link {

--- a/app/src/routes/ExplorationView/ExplorationView.css
+++ b/app/src/routes/ExplorationView/ExplorationView.css
@@ -1,12 +1,12 @@
 * {
   box-sizing: border-box;
-  padding: 0;
   margin: 0 0;
+  padding: 0;
 }
 
 .main {
-  padding: 0 10px;
   margin-left: 417px; /* Same as the width of the sidenav */
+  padding: 0 10px;
 }
 
 #openedSidebar {
@@ -20,22 +20,22 @@
 h1 {
   position: relative;
   margin: 20px;
+  color: #175578;
   font-size: 2.5rem;
   font-weight: bold;
-  color: #175578;
   text-align: center;
 }
 
 h2 {
   position: relative;
-  font-size: 1.8rem;
   color: #000;
+  font-size: 1.8rem;
   text-align: center;
 }
 
 h3 {
   position: relative;
-  font-size: 1.2rem;
   color: #000;
+  font-size: 1.2rem;
   text-align: center;
 }

--- a/app/src/routes/ExplorationView/ExplorationView.css
+++ b/app/src/routes/ExplorationView/ExplorationView.css
@@ -1,12 +1,12 @@
 * {
   box-sizing: border-box;
-  margin: 0 0;
   padding: 0;
+  margin: 0 0;
 }
 
 .main {
-  margin-left: 417px; /* Same as the width of the sidenav */
   padding: 0 10px;
+  margin-left: 417px; /* Same as the width of the sidenav */
 }
 
 #openedSidebar {
@@ -19,23 +19,23 @@
 
 h1 {
   position: relative;
-  font-size: 2.5rem;
-  text-align: center;
-  font-weight: bold;
   margin: 20px;
+  font-size: 2.5rem;
+  font-weight: bold;
   color: #175578;
+  text-align: center;
 }
 
 h2 {
   position: relative;
   font-size: 1.8rem;
-  text-align: center;
   color: #000;
+  text-align: center;
 }
 
 h3 {
   position: relative;
   font-size: 1.2rem;
-  text-align: center;
   color: #000;
+  text-align: center;
 }

--- a/app/src/routes/ExplorationView/ExplorationView.css
+++ b/app/src/routes/ExplorationView/ExplorationView.css
@@ -1,41 +1,41 @@
 * {
-    box-sizing: border-box;
-    margin: 0 0;
-    padding: 0;
+  box-sizing: border-box;
+  margin: 0 0;
+  padding: 0;
 }
 
-.main{
-    margin-left: 417px; /* Same as the width of the sidenav */
-    padding: 0px 10px;
+.main {
+  margin-left: 417px; /* Same as the width of the sidenav */
+  padding: 0 10px;
 }
 
 #openedSidebar {
-    margin-left: 417px; /* Same as the width of the sidenav */
+  margin-left: 417px; /* Same as the width of the sidenav */
 }
 
 #closedSidebar {
-    margin-left: 50px;
+  margin-left: 50px;
 }
 
 h1 {
-    position: relative;
-    font-size: 2.5rem;
-    text-align: center;
-    font-weight: bold;
-    margin: 20px;
-    color: #175578;
+  position: relative;
+  font-size: 2.5rem;
+  text-align: center;
+  font-weight: bold;
+  margin: 20px;
+  color: #175578;
 }
 
 h2 {
-    position: relative;
-    font-size: 1.8rem;
-    text-align: center;
-    color: #000000;
+  position: relative;
+  font-size: 1.8rem;
+  text-align: center;
+  color: #000;
 }
 
 h3 {
-    position: relative;
-    font-size: 1.2rem;
-    text-align: center;
-    color: #000000;
+  position: relative;
+  font-size: 1.2rem;
+  text-align: center;
+  color: #000;
 }

--- a/app/src/routes/LandingPages/LandingPages.css
+++ b/app/src/routes/LandingPages/LandingPages.css
@@ -1,35 +1,35 @@
 * {
-    box-sizing: border-box;
-    margin: 0 0;
-    padding: 0;
+  box-sizing: border-box;
+  margin: 0 0;
+  padding: 0;
 }
 
-.main{
-    padding: 0px 10px;
+.main {
+  padding: 0 10px;
 }
 
 #openedSidebar {
-    margin-left: 417px; /* Same as the width of the sidenav */
+  margin-left: 417px; /* Same as the width of the sidenav */
 }
 
 #closedSidebar {
-    margin-left: 50px;
+  margin-left: 50px;
 }
 
 h1 {
-    position: relative;
-    font-size: 48px;
-    line-height: 56px;
-    text-align: center;
-    font-weight: bold;
-    margin-top: 20px;
-    color: #175578;
+  position: relative;
+  font-size: 48px;
+  line-height: 56px;
+  text-align: center;
+  font-weight: bold;
+  margin-top: 20px;
+  color: #175578;
 }
 
 h2 {
-    position: relative;
-    font-size: 36px;
-    line-height: 42px;
-    text-align: center;
-    color: #000000;
+  position: relative;
+  font-size: 36px;
+  line-height: 42px;
+  text-align: center;
+  color: #000;
 }

--- a/app/src/routes/LandingPages/LandingPages.css
+++ b/app/src/routes/LandingPages/LandingPages.css
@@ -1,7 +1,7 @@
 * {
   box-sizing: border-box;
-  margin: 0 0;
   padding: 0;
+  margin: 0 0;
 }
 
 .main {
@@ -18,18 +18,18 @@
 
 h1 {
   position: relative;
-  font-size: 48px;
-  line-height: 56px;
-  text-align: center;
-  font-weight: bold;
   margin-top: 20px;
+  font-size: 48px;
+  font-weight: bold;
+  line-height: 56px;
   color: #175578;
+  text-align: center;
 }
 
 h2 {
   position: relative;
   font-size: 36px;
   line-height: 42px;
-  text-align: center;
   color: #000;
+  text-align: center;
 }

--- a/app/src/routes/LandingPages/LandingPages.css
+++ b/app/src/routes/LandingPages/LandingPages.css
@@ -1,7 +1,7 @@
 * {
   box-sizing: border-box;
-  padding: 0;
   margin: 0 0;
+  padding: 0;
 }
 
 .main {
@@ -19,17 +19,17 @@
 h1 {
   position: relative;
   margin-top: 20px;
+  color: #175578;
   font-size: 48px;
   font-weight: bold;
   line-height: 56px;
-  color: #175578;
   text-align: center;
 }
 
 h2 {
   position: relative;
+  color: #000;
   font-size: 36px;
   line-height: 42px;
-  color: #000;
   text-align: center;
 }

--- a/app/src/routes/LandingPages/RootLandingPage/RootLandingPage.css
+++ b/app/src/routes/LandingPages/RootLandingPage/RootLandingPage.css
@@ -4,38 +4,38 @@
 
 .heading {
   position: relative;
-  font-size: 3.5rem;
-  text-align: center;
-  font-weight: bold;
   margin-top: 10%;
+  font-size: 3.5rem;
+  font-weight: bold;
   color: #175578;
+  text-align: center;
 }
 
 .description {
-  margin-top: 20px;
   position: relative;
+  margin-top: 20px;
   font-size: 2.2rem;
-  text-align: center;
   color: #000;
+  text-align: center;
 }
 
 .enterbutton {
-  background-color: #fff;
-  color: #175578;
-  margin-top: 100px;
-  margin-left: 50px;
-  margin-right: 50px;
   display: inline-block;
-  cursor: pointer;
-  padding: 10px;
-  font-size: 1.5rem;
-  border-color: #175578;
-  border-width: 3px;
-  border-style: solid;
   width: 300px;
+  padding: 10px;
+  margin-top: 100px;
+  margin-right: 50px;
+  margin-left: 50px;
+  font-size: 1.5rem;
+  color: #175578;
+  cursor: pointer;
+  background-color: #fff;
+  border-color: #175578;
+  border-style: solid;
+  border-width: 3px;
 }
 
 .enterbutton:hover {
-  background: #f1f1f1;
   color: #175578;
+  background: #f1f1f1;
 }

--- a/app/src/routes/LandingPages/RootLandingPage/RootLandingPage.css
+++ b/app/src/routes/LandingPages/RootLandingPage/RootLandingPage.css
@@ -1,47 +1,41 @@
-.frame{
-    text-align: center;
+.frame {
+  text-align: center;
 }
 
-.heading{
-    position: relative;
-    font-size: 3.5rem;
-    text-align: center;
-    font-weight: bold;
-    margin-top: 10%;
-    color: #175578;
+.heading {
+  position: relative;
+  font-size: 3.5rem;
+  text-align: center;
+  font-weight: bold;
+  margin-top: 10%;
+  color: #175578;
 }
 
 .description {
-    margin-top: 20px;
-    position: relative;
-    font-size: 2.2rem;
-    text-align: center;
-    color: #000000;
+  margin-top: 20px;
+  position: relative;
+  font-size: 2.2rem;
+  text-align: center;
+  color: #000;
 }
 
-.enterbutton{
-    background-color: #FFFFFF;
-    color: #175578;
-    margin-top: 100px;
-    margin-left: 50px;
-    margin-right: 50px;
-    display: inline-block;
-    cursor: pointer;
-    padding: 10px;
-    font-size: 1.5rem;
-    border-color: #175578;
-    border-width: 3px;
-    border-style: solid;
-    width: 300px;
+.enterbutton {
+  background-color: #fff;
+  color: #175578;
+  margin-top: 100px;
+  margin-left: 50px;
+  margin-right: 50px;
+  display: inline-block;
+  cursor: pointer;
+  padding: 10px;
+  font-size: 1.5rem;
+  border-color: #175578;
+  border-width: 3px;
+  border-style: solid;
+  width: 300px;
 }
 
-.enterbutton:hover{
-    background: #f1f1f1;
-    color: #175578;
+.enterbutton:hover {
+  background: #f1f1f1;
+  color: #175578;
 }
-
-
-
-
-
-

--- a/app/src/routes/LandingPages/RootLandingPage/RootLandingPage.css
+++ b/app/src/routes/LandingPages/RootLandingPage/RootLandingPage.css
@@ -5,37 +5,37 @@
 .heading {
   position: relative;
   margin-top: 10%;
+  color: #175578;
   font-size: 3.5rem;
   font-weight: bold;
-  color: #175578;
   text-align: center;
 }
 
 .description {
   position: relative;
   margin-top: 20px;
-  font-size: 2.2rem;
   color: #000;
+  font-size: 2.2rem;
   text-align: center;
 }
 
 .enterbutton {
   display: inline-block;
   width: 300px;
-  padding: 10px;
   margin-top: 100px;
   margin-right: 50px;
   margin-left: 50px;
-  font-size: 1.5rem;
-  color: #175578;
-  cursor: pointer;
-  background-color: #fff;
-  border-color: #175578;
-  border-style: solid;
+  padding: 10px;
   border-width: 3px;
+  border-style: solid;
+  border-color: #175578;
+  background-color: #fff;
+  color: #175578;
+  font-size: 1.5rem;
+  cursor: pointer;
 }
 
 .enterbutton:hover {
-  color: #175578;
   background: #f1f1f1;
+  color: #175578;
 }

--- a/app/src/routes/NotFound/NotFound.css
+++ b/app/src/routes/NotFound/NotFound.css
@@ -1,0 +1,1 @@
+/* not required yet */


### PR DESCRIPTION
We should use a css linter to guarantee compliance with our coding standards.
This PR includes "stylelint" with its basic rule set. All CSS files were fixed accordingly.

*Introduced npm commands:*
- `npm run csslint`: Run CSS linter
- `npm run csslint-fix`: Let stylelint attempt to fix issues

For the best experience, install the VSCode "stylelint/stylelint" plugin :)